### PR TITLE
Fix 82599 T3: additions

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -174,6 +174,10 @@ function selftest ()
    sq_sq(pcideva, pcidevb)
    if device_info_a.model == pci.model["82599_T3"] or
          device_info_b.model == pci.model["82599_T3"] then
+      -- Test experience in the lab suggests that the 82599 T3 NIC
+      -- requires at least two seconds before it will reliably pass
+      -- traffic. The test case sleeps for this reason.
+      -- See https://github.com/SnabbCo/snabbswitch/pull/569
       C.usleep(2e6)
    end
    engine.main({duration = 1, report={showlinks=true, showapps=false}})

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -68,7 +68,7 @@ local cards = {
       ["0x151c"] = {model = model["82599_T3"],  driver = 'apps.intel.intel_app'},
    },
    ["0x1924"] =  {
-      ["0x0903"] = {model = '', driver = 'apps.solarflare.solarflare'}
+      ["0x0903"] = {model = 'SFN7122F', driver = 'apps.solarflare.solarflare'}
    },
 }
 


### PR DESCRIPTION
This adds a couple of small things to SnabbCo/snabbswitch#569:
1. Add a comment about the 2-second sleep for the T3 NIC (with a link to the Github discussion).
2. Add the model name for the supported Solarflare card to PCI module.
