### PR TITLE
Fix error on valid 'snabb config set' invocation

### DIFF
--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -221,7 +221,7 @@ local function ietf_softwire_translator ()
       br_instance[br_instance_key_t({id=1})] = {
          tunnel_payload_mtu = native_config.softwire_config.internal_interface.mtu,
          tunnel_path_mru = native_config.softwire_config.external_interface.mtu,
-         -- FIXME
+         -- FIXME: What it should map to?
          softwire_num_threshold = 0xffffffff,
          binding_table = {
             binding_entry = ietf_binding_table_from_native(
@@ -276,7 +276,7 @@ local function ietf_softwire_translator ()
                                  'br-instances', 'br-instance'}
       local bt_paths = {'binding-table', 'binding-entry'}
 
-      -- Handle special br attributes (tunnel-payload-mtu, tunnel-path-mru)
+      -- Handle special br attributes (tunnel-payload-mtu, tunnel-path-mru, softwire-num-threshold)
       if #path > #br_instance_paths then
          if path[#path].name == 'tunnel-payload-mtu' then
             return {{'set', {schema='snabb-softwire-v1',
@@ -288,6 +288,11 @@ local function ietf_softwire_translator ()
                      path="/softwire-config/external-interface/mtu",
                      config=tostring(arg)}}}
          end
+         if path[#path].name == 'softwire-num-threshold' then
+            -- FIXME: Do nothing.
+            return {}
+         end
+         error('unrecognized leaf: '..path[#path].name)
       end
 
       -- Two kinds of updates: setting the whole binding table, or


### PR DESCRIPTION
Depends on #694. Fixes #677.

The set command does nothing, because there's not equivalent value of softwire-num-threshold in snabb-software-v1 AFAIK, but at least it fixes the error.